### PR TITLE
reduce yarn audit output size

### DIFF
--- a/bin/improved-yarn-audit
+++ b/bin/improved-yarn-audit
@@ -147,7 +147,14 @@ async function handleAuditNetworkError(output) {
 
 async function invokeYarnAudit() {
   let stdOutAndErr = []
-  let yarnProcess = child_process.spawn("yarn", ["audit", "--json"])
+  
+  let auditParams = ["audit", "--json", `--level=${minSeverityName}`];
+  
+  if(ignoreDevDependecies) {
+    auditParams.push("--groups=dependencies")
+  }
+  
+  let yarnProcess = child_process.spawn("yarn", auditParams)
 
   yarnProcess.stdout.on("data", d => stdOutAndErr.push(d))
   yarnProcess.stderr.on("data", d => stdOutAndErr.push(d))


### PR DESCRIPTION
`yarn audit --json > audit-output.json` can generate a file over 1Gb, and exceed the maximum stack size in improved-yarn-audit context.

adding filters in the `yarn audit` command can helps mitigate this issue