### PR TITLE
Allow empty .iyarc  (contains no exclusions)

### DIFF
--- a/bin/improved-yarn-audit
+++ b/bin/improved-yarn-audit
@@ -466,9 +466,8 @@ function errorAndExit(msg) {
 }
 
 function isNumbersCsv(str) {
-  return str.trim()
-    .replace(/\s/g, "")    // filter out spaces
-    .match(/^(,|\d)*\d$/)  // number csv regex (without spaces)
+  const numbers = str.trim().replace(/\s/g, "") // filter out spaces
+  return isNullOrEmpty(numbers) || numbers.match(/^(,|\d)*\d$/) // number csv regex (without spaces)
 }
 
 function isNullOrEmpty(str) {

--- a/test/test.sh
+++ b/test/test.sh
@@ -153,6 +153,11 @@ runTests() {
   # test 20
   callIya -d
   testExitCode "--debug is passed" "7" "$?"
+
+  #test 21
+  echo "#" > .iyarc
+  callIya
+  testExitCode ".iyarc contains no exclusions" "7" "$?"
 }
 
 runTests


### PR DESCRIPTION
We typically stay pretty current with managing our exclusions. It's not unusual for us to oscillate between 0 and 1 at any given time. We prefer to use the `.iyarc` file approach because it allows us to add comments with links to the specific advisories. Presently, if all exclusions are removed from the `.iyarc` file then running `yarn improved-yarn-audit` results in the following error:
```
ERROR: .iyarc is not in the correct format, excluded advisories must be provided as a CSV list, for example: '2341,21,43'
```
This causes us to have to frequently delete/recreate the `.iyarc` file. This PR proposes a small change (with a corresponding test) that handles the scenario when the `.iyarc` file is empty (contains no exclusions) without generating an error.