### PR TITLE
Allow iyarc to include linebreaks between advisory codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,22 @@ yarn run improved-yarn-audit --exclude 253,456,811
 
 ## .iyarc File
 
-If an `.iyarc` file is present in the current working directory, it will be parsed and used to specify a CSV list of advisory exclusions.
+If an `.iyarc` file is present in the current working directory, it will be parsed and used to specify a list of advisory exclusions.
+
+Advisory exclusions to be ignored can either be provided on their own line, or as a comma separated list.
 
 Example `.iyarc` file:
 
 ```bash
 # This file can contain comments, you could do something like:
-#
 # 34 is ignored because there is no fix available (last checked 20th March 2020)
-#
-34,53,124
+34
+
+# This one doesn't affect us
+1435
+
+# Let's ignore these too
+46,53,124
 ```
 
 **Note: if you pass in exclusions using the command line, these will override the `.iyarc` file**

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Example `.iyarc` file:
 # This one doesn't affect us
 1435
 
-# Let's ignore these too
+# We can also ignore all these, as a comma separated list
 46,53,124
 ```
 

--- a/bin/improved-yarn-audit
+++ b/bin/improved-yarn-audit
@@ -506,10 +506,11 @@ function loadExclusionsFromFileIfPresent() {
     return
   }
 
-  let advisoriesCsv = readFileSync(exclusionsFileName)
+  let matchedAdvisories = readFileSync(exclusionsFileName)
     .toString()
-    .match(/(?<=^(?:\d+,)*)\d+(?=(?:,\d+)*$)/gm)
-    .join(',')
+    .match(/(?<=^(?:\d+,)*)\d+(?=(?:,\d+)*$)/gm);
+
+  let advisoriesCsv = matchedAdvisories ? matchedAdvisories.join(',') : '';
 
   logDebug(`.iyarc contents (excluding comments): ${advisoriesCsv}`)
 

--- a/bin/improved-yarn-audit
+++ b/bin/improved-yarn-audit
@@ -508,13 +508,14 @@ function loadExclusionsFromFileIfPresent() {
 
   let advisoriesCsv = readFileSync(exclusionsFileName)
     .toString()
-    .replace(/^\s*#.*$/mg, "") // ignore comment lines, if present
+    .match(/(?<=^(?:\d+,)*)\d+(?=(?:,\d+)*$)/gm)
+    .join(',')
 
   logDebug(`.iyarc contents (excluding comments): ${advisoriesCsv}`)
 
   if (!isNumbersCsv(advisoriesCsv)) {
-    errorAndExit(`ERROR: ${exclusionsFileName} is not in the correct format, excluded advisories must be provided as ` +
-      "a CSV list, for example: '2341,21,43'")
+    errorAndExit(`ERROR: ${exclusionsFileName} is not in the correct format, excluded advisories must be provided on ` +
+      "individual lines, or as a CSV list (eg: '2341,21,43')")
   }
 
   console.log(`Reading excluded advisories from ${exclusionsFileName}`)

--- a/test/test.sh
+++ b/test/test.sh
@@ -48,7 +48,7 @@ runTests() {
   testExitCode "vulnerabilities are present and they are excluded on the command line" "0" "$?"
 
   # test 3
-  echo "${excludedAdvisories}" > .iyarc
+  echo $'3\n\n8\n28\n\n29\n535,880,1469' > .iyarc
 
   callIya
   testExitCode "vulnerabilities are present and they are excluded in .iyarc" "0" "$?"
@@ -57,7 +57,7 @@ runTests() {
   echo "# excluding 3 because I feel like it, ok?" > .iyarc
   echo "#" >> .iyarc
   echo "##" >> .iyarc
-  echo "${excludedAdvisories}" >> .iyarc
+  echo $'3\n\n8\n28\n\n29\n535,880,1469' >> .iyarc
 
   callIya
   testExitCode "they are excluded in .iyarc file with comments" "0" "$?"


### PR DESCRIPTION
PR proposal to allow linebreaks in the `.iyarc` file, allowing advisories to be placed on their own line, rather than just in CSV format.

This has benefits for version control, as additions/removals to the file will be possible on their own line with their own commit history, rather than updating the history for a single line. It also allows for comments to be placed next to the specific advisory.

This is a backwards compatible change, so that the original csv format will still work. This change just parses any numbers on their own line + comma separated numbers back into the original csv format.

Example `.iyarc`:
```bash
# 34 is ignored because there is no fix available (last checked 20th March 2020)
34

# This one doesn't affect us
1435

# We can also ignore all these, as a comma separated list
46,53,124
```

Regex example: https://regex101.com/r/ZCA3ob/2