### PR TITLE
Fix ENOBUFS error when there's huge amounts of output

### DIFF
--- a/bin/improved-yarn-audit
+++ b/bin/improved-yarn-audit
@@ -274,22 +274,31 @@ async function invokeYarnAudit() {
   cleanupAuditResultsFile()
 
   const auditResultsFileStream = getAuditResultsFileStream("w")
-  const yarnBinaryPostFix = isWindows ? ".cmd" : ""
-  const yarnProcess = spawn(`yarn${yarnBinaryPostFix}`, auditParams, { env: env })
 
-  yarnProcess.stdout.pipe(auditResultsFileStream)
-  yarnProcess.stderr.pipe(auditResultsFileStream)
+  return new Promise(resolve => {
+    auditResultsFileStream.on("open", async () => {
+      const yarnBinaryPostFix = isWindows ? ".cmd" : ""
+      const yarnProcess = spawn(`yarn${yarnBinaryPostFix}`, auditParams, {
+        env: env,
+        stdio: [
+          'pipe',
+          auditResultsFileStream,
+          auditResultsFileStream,
+        ]
+      })
 
-  let exitCode = await new Promise((resolve, reject) =>
-    yarnProcess.on("exit", resolve)
-      .on("error", reject)
-  )
+      let exitCode = await new Promise((resolve, reject) =>
+      yarnProcess.on("exit", resolve)
+        .on("error", reject)
+      )
 
-  auditResultsFileStream.close()
+      auditResultsFileStream.close()
 
-  logDebug(() => `Yarn audit output size: ${statSync(auditResultsFilePath).size} bytes`)
+      logDebug(() => `Yarn audit output size: ${statSync(auditResultsFilePath).size} bytes`)
 
-  return exitCode
+      resolve(exitCode);
+    });
+  })
 }
 
 async function runYarnAudit() {


### PR DESCRIPTION
Using `pipe` appears to create the possibility of `ENOBUFS` errors when there's huge amounts of advisories/text.

Whereas using the method in this PR to pipe the outputs doesn't cause that error.

BEFORE:
```
npx improved-yarn-audit --ignore-dev-deps --min-severity high

... normal output ...

/usr/share/yarn/lib/cli.js:92892  throw err;  ^Error: write ENOBUFS    at afterWriteDispatched (internal/stream_base_commons.js:154:25)    at writevGeneric (internal/stream_base_commons.js:137:3)    at Socket._writeGeneric (net.js:784:11)    at Socket._writev (net.js:793:8)    at doWrite (_stream_writable.js:401:12)    at clearBuffer (_stream_writable.js:519:5)    at onwrite (_stream_writable.js:454:7)    at WriteWrap.onWriteComplete [as oncomplete] (internal/stream_base_commons.js:101:10) {  errno: 'ENOBUFS',  code: 'ENOBUFS',  syscall: 'write'}
```

The heart of the error really feels like: https://github.com/yarnpkg/yarn/issues/7404 `yarn audit --json produces large amounts of data`

Running `yarn audit --json` produces 922MiB of data using Merit's monorepo :exploding_head:

Nevertheless, changing stream handling as per this PR appears to fix the error, no matter how silly the JSON size gets
