### PR TITLE
Now passing "shell: true" to "spawn" on Windows to prevent EINVAL

### DIFF
--- a/bin/improved-yarn-audit
+++ b/bin/improved-yarn-audit
@@ -340,6 +340,7 @@ async function streamYarnAuditOutput(auditParams, auditResultsFileStream) {
   const yarnBinaryPostFix = isWindows ? ".cmd" : ""
   const yarnProcess = spawn(`yarn${yarnBinaryPostFix}`, auditParams, {
     env: env,
+    shell: isWindows,
     stdio: ["pipe", auditResultsFileStream, auditResultsFileStream]
   })
 


### PR DESCRIPTION
Since [Node.js 20.12.2](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#2024-04-10-version-20122-iron-lts-rafaelgss), calling `spawn()` without `shell: true` results in `EINVAL` on Windows. 
https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high

This PR sets `shell: true` on Windows to make sure it continues working.

Closes #37 